### PR TITLE
Fix: Add Header/Footer to Careers Page and Link Careers Section

### DIFF
--- a/src/components/CareersSection.tsx
+++ b/src/components/CareersSection.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export const CareersSection: React.FC = () => {
   return (
-    <section id="careers" className="min-w-60 w-full max-w-[960px] overflow-hidden flex-1 shrink basis-[0%] max-md:max-w-full">
-      <div className="flex w-full flex-col items-stretch text-white justify-center p-4 max-md:max-w-full">
-        <div className="flex flex-col relative min-h-[246px] w-full overflow-hidden pt-[157px] pb-[31px] px-6 rounded-xl max-md:max-w-full max-md:pt-[100px] max-md:px-5">
-          <img
+    <Link to="/careers" className="contents">
+      <section id="careers" className="min-w-60 w-full max-w-[960px] overflow-hidden flex-1 shrink basis-[0%] max-md:max-w-full">
+        <div className="flex w-full flex-col items-stretch text-white justify-center p-4 max-md:max-w-full">
+          <div className="flex flex-col relative min-h-[246px] w-full overflow-hidden pt-[157px] pb-[31px] px-6 rounded-xl max-md:max-w-full max-md:pt-[100px] max-md:px-5">
+            <img
             src="https://cdn.builder.io/api/v1/image/assets/8dc629ae2a5d45d08901e6df864c4154/c5efaa9bafa0d77c9c6a2c70910e96bacd7c34ff?placeholderIfAbsent=true"
             className="absolute h-full w-full object-cover inset-0"
             alt="Careers at Mundus"
@@ -23,5 +25,6 @@ export const CareersSection: React.FC = () => {
       </div>
       <div className="flex min-h-10 w-full max-md:max-w-full" />
     </section>
+    </Link>
   );
 };

--- a/src/pages/CareersPage/Index.tsx
+++ b/src/pages/CareersPage/Index.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import { Header } from '../../components/Header';
 import { JobListing } from '../../components/CareersPageComponents/JobListing';
 import { ValueCard } from '../../components/CareersPageComponents/ValueCard';
 import { ContactItem } from '../../components/CareersPageComponents/ContactItem';
+import { Footer } from '../../components/Footer';
 
 const Index: React.FC = () => {
   const [showReserveForm, setShowReserveForm] = useState(false);
@@ -67,6 +69,7 @@ const Index: React.FC = () => {
   return (
     <div className="bg-white">
       <div className="bg-[rgba(26,26,26,1)] min-h-[800px] w-full overflow-hidden max-md:max-w-full">
+        <Header />
         <div className="w-full max-md:max-w-full">
           
           <main className="flex w-full justify-center mt-[49px] pt-5 pb-[69px] px-40 max-md:max-w-full max-md:mt-10 max-md:px-5">
@@ -166,6 +169,9 @@ const Index: React.FC = () => {
             </div>
           </section>
 
+        </div>
+        <div className="flex w-full justify-center px-40 max-md:max-w-full max-md:px-5">
+          <Footer />
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit addresses two issues:

1.  The Careers page (`/careers`) was missing the common Header and Footer components. They have been added to `src/pages/CareersPage/Index.tsx`, ensuring a consistent layout with other pages.
2.  The "Careers" section on the homepage was not interactive. It has been updated in `src/components/CareersSection.tsx` to link directly to the `/careers` page, improving navigation.